### PR TITLE
Fix email validation to allow for period between @ and .com

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -101,7 +101,7 @@ const App = () => {
                     mask={[
                       { regexp: /^[\w\-_.]+$/, placeholder: 'sample' },
                       { fixed: '@' },
-                      { regexp: /^[\w]+$/, placeholder: 'email' },
+                      { regexp: /^[\w.]+$/, placeholder: 'email' },
                       { fixed: '.' },
                       { regexp: /^[\w]+$/, placeholder: 'com' },
                     ]}


### PR DESCRIPTION
Allows for emails with a period between the @ and the .com part. For example myname@us.company.com
Solves https://github.com/grommet/grommet/issues/5051